### PR TITLE
Fix use after frees during release

### DIFF
--- a/module/driver.c
+++ b/module/driver.c
@@ -285,6 +285,8 @@ static void vm_close(struct vm_area_struct *vma) {
 
 	// Raise the locked_vm_pages again
 	// exmap_unaccount_mem(ctx, ctx->buffer_size);
+	
+	ctx->exmap_vma = NULL;
 
 	pr_info("vm_close:  freed: %lu, unlock=%lu\n",
 			freed_pages, unlocked_pages);

--- a/module/driver.c
+++ b/module/driver.c
@@ -367,6 +367,13 @@ static int exmap_mmu_notifier(struct exmap_ctx *ctx)
 	return mmu_notifier_register(&ctx->mmu_notifier, current->mm);
 }
 
+static void exmap_mmu_notifier_unregister(struct exmap_ctx *ctx)
+{
+	if (current->mm) {
+		mmu_notifier_unregister(&ctx->mmu_notifier, current->mm);
+	}
+}
+
 static int exmap_mmap(struct file *file, struct vm_area_struct *vma) {
 	struct exmap_ctx *ctx = file->private_data;
 	loff_t offset = vma->vm_pgoff << PAGE_SHIFT;
@@ -504,6 +511,8 @@ static int release(struct inode *inode, struct file *filp) {
 		}
 		kvfree(ctx->interfaces);
 	}
+
+	exmap_mmu_notifier_unregister(ctx);
 
 	pr_info("release\n");
 


### PR DESCRIPTION
There are two use after frees when freeing/unmapping in the following order (tested on kvm/qemu):

1. Unmap interfaces
2. Unmap vm area
3. Finally close the file descriptor

The program I used is [here](https://github.com/jordanisaacs/exmap/blob/b4b737edb57c782f768411f05288699ba3f1d5c2/src/bin.rs).

The first use after free occurs in `__mmu_notifier_invalidate_range_start` which seems to be because the notifier events are not unregistered. Release can occur in a kernel thread so check that `current->mm` exists. The second is due to the `ctx->exmap_vma` not being set to `NULL` when it is closed/unmapped. This causes `exmap_notifier_release` to run cleanup even if `exmap_vma` was closed.