### PR TITLE
Null check in unmap fastpath

### DIFF
--- a/module/memory.c
+++ b/module/memory.c
@@ -560,8 +560,10 @@ more:
 			pte = pte_offset_map(pmd, addr);
 			page = unmap_page_fastpath(pte);
 
-			push_page(page, &ctx->interface->local_pages, ctx->ctx);
-			ctx->pages_count++;
+			if (page) {
+			    push_page(page, &ctx->interface->local_pages, ctx->ctx);
+			    ctx->pages_count++;
+			}
 
 			remaining_pages_total -=1;
 			addr += PAGE_SIZE;


### PR DESCRIPTION
When unmapping a page there is the possibility that no page exists for the address and `unmap_page_fastpath()` returns `NULL`. This causes a null pointer to be pushed into the interface local pages. And eventually causes errors elsewhere. Fix by adding a null check.