### PR TITLE
Fix exmap compiled with linux 6.2 to 6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ modules.builtin
 *.gcno
 
 Module.symvers
+
+/eval/test-*

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ modules.builtin
 Module.symvers
 
 /eval/test-*
+!/eval/*.cc

--- a/module/driver.c
+++ b/module/driver.c
@@ -395,11 +395,11 @@ static int exmap_mmap(struct file *file, struct vm_area_struct *vma) {
 
 		vma->vm_ops   = &vm_ops;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
-	vm_flags_set(vma, VM_DONTEXPAND);
-	vm_flags_set(vma, VM_DONTDUMP);
-	vm_flags_set(vma, VM_NOHUGEPAGE);
-	vm_flags_set(vma, VM_DONTCOPY);
-	vm_flags_set(vma, VM_MIXEDMAP);
+		vm_flags_set(vma, VM_DONTEXPAND);
+		vm_flags_set(vma, VM_DONTDUMP);
+		vm_flags_set(vma, VM_NOHUGEPAGE);
+		vm_flags_set(vma, VM_DONTCOPY);
+		vm_flags_set(vma, VM_MIXEDMAP);
 #else
 		vma->vm_flags |= VM_DONTEXPAND | VM_DONTDUMP | VM_NOHUGEPAGE | VM_DONTCOPY;
 		vma->vm_flags |= VM_MIXEDMAP; // required for vm_insert_page

--- a/module/driver.h
+++ b/module/driver.h
@@ -98,5 +98,5 @@ pmd_t * exmap_walk_to_pmd(struct vm_area_struct *vma,
 						  unsigned long addr);
 
 // #define exmap_debug(...) pr_info("exmap:" __VA_ARGS__)
-#define exmap_debug(...) 
+#define exmap_debug(...)
 

--- a/module/linux/exmap.h
+++ b/module/linux/exmap.h
@@ -93,10 +93,3 @@ typedef enum exmap_flags exmap_flags;
 
 
 #define SYS_EXMAP_ACTION 400
-
-struct exmap_action_params {
-	uint16_t interface;
-	uint16_t iov_len;
-	uint16_t opcode; // exmap_opcode
-	uint64_t flags;  // exmap_flags
-};


### PR DESCRIPTION
There are many changes in Linux 6.2 -> 6.5, compared to Linux <= 6.1
I made this patch to address the compatibility issues.

